### PR TITLE
Avoid deprecation warnings for private structure fields

### DIFF
--- a/steamwrap/data/ControllerConfig.hx
+++ b/steamwrap/data/ControllerConfig.hx
@@ -255,11 +255,11 @@ class ControllerConfig
 }
 
 typedef ControllerActionSet = {
-	private var name:String;
-	private var localizationKey:String;
-	private var button:Array<ButtonAction>;
-	private var analogTrigger:Array<AnalogTriggerAction>;
-	private var stickPadGyro:Array<StickPadGyroAction>;
+	var name:String;
+	var localizationKey:String;
+	var button:Array<ButtonAction>;
+	var analogTrigger:Array<AnalogTriggerAction>;
+	var stickPadGyro:Array<StickPadGyroAction>;
 };
 
 //typedef ControllerAction = OneOfThree<ButtonAction,AnalogTriggerAction,StickPadGyroAction>;


### PR DESCRIPTION
Not sure in which Haxe version these were introduced, but latest Haxe spits out these warnings:

```
SteamWrap/steamwrap/data/ControllerConfig.hx:258: characters 2-9 : Warning : private structure fields are deprecated
SteamWrap/steamwrap/data/ControllerConfig.hx:259: characters 2-9 : Warning : private structure fields are deprecated
SteamWrap/steamwrap/data/ControllerConfig.hx:260: characters 2-9 : Warning : private structure fields are deprecated
SteamWrap/steamwrap/data/ControllerConfig.hx:261: characters 2-9 : Warning : private structure fields are deprecated
SteamWrap/steamwrap/data/ControllerConfig.hx:262: characters 2-9 : Warning : private structure fields are deprecated
```

Doesn't seem like these really need to be private.