### PR TITLE
Fix for #31

### DIFF
--- a/README.md
+++ b/README.md
@@ -92,6 +92,8 @@ Or you can set it up manually:
 		STEAMSDK_DIR/public/steam/*.h -> native/include/steam/*.h
 		STEAMSDK_DIR/redistributable_bin/steam_api.dll -> native/lib/win32/
 		STEAMSDK_DIR/redistributable_bin/steam_api.lib -> native/lib/win32/
+		STEAMSDK_DIR/redistributable_bin/win64/steam_api64.dll -> native/lib/win64/
+		STEAMSDK_DIR/redistributable_bin/win64/steam_api64.lib -> native/lib/win64/
 		STEAMSDK_DIR/redistributable_bin/osx32/libsteam_api.dylib -> native/lib/osx64/
 		STEAMSDK_DIR/redistributable_bin/linux32/libsteam_api.so -> native/lib/linux32/
 		STEAMSDK_DIR/redistributable_bin/linux64/libsteam_api.so -> native/lib/linux64/
@@ -101,7 +103,10 @@ Or you can set it up manually:
 	Windows:
 	```
 		ndll/Windows/steam_appid.txt
-		STEAMSDK_DIR/redistributable_bin/steam_api.dll -> ndll/Windows
+		STEAMSDK_DIR/redistributable_bin/steam_api.dll -> ndll/Windows/
+
+		ndll/Windows64/steam_appid.txt
+		STEAMSDK_DIR/redistributable_bin/steam_api64.dll -> ndll/Windows64/
 	```
 
 	Mac:

--- a/native/lib/win64/put_steam_api64_dll_and_lib_here.txt
+++ b/native/lib/win64/put_steam_api64_dll_and_lib_here.txt
@@ -1,0 +1,1 @@
+put steam_api64.dll and steam_api64.lib in this folder


### PR DESCRIPTION
This fixes an issue when building 64-bit Windows games where it copies the 32-bit steam_api.dll instead of the 64-bit steam_api64.dll.